### PR TITLE
Fix array.join argument

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -99,7 +99,7 @@ function runArrayJoinExperiment(base, power, size) {
     for (var i = 0; i < size; i++) {
         builder.push(i%10);
     }
-    var result = builder.join();
+    var result = builder.join("");
     var end = new Date().getTime();
     var duration = end - start;
     console.log("join %d^%d %d %d %d", base, power, size, result.length, duration);

--- a/experiment.js
+++ b/experiment.js
@@ -114,6 +114,7 @@ function runExperiment(options, rustStringBuilderFunction){
     const defaultOptions = {
         powerLimit:27,
         base:2,
+        timeout:2000 // cut off longer than 2000 ms
     };
     for(let key in defaultOptions){
         if(!(key in options))options[key] = defaultOptions[key];
@@ -136,6 +137,7 @@ function runExperiment(options, rustStringBuilderFunction){
                 }
             }
             const duration = experiments[expName](options.base, power, size);
+            if(duration > options.timeout)timedOuts.add(expName);
             result[expName+"Duration"] = duration;
         }
         results.push(result);


### PR DESCRIPTION
With the original blank argument, array.join will insert "," in between elements.
This can be fixed by explicitly providing "" as the argument.
By doing so, this PR will make the behavior of the join experiment consistent with the other experiments.