### PR TITLE
Fix array.join argument

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -99,7 +99,7 @@ function runArrayJoinExperiment(base, power, size) {
     for (var i = 0; i < size; i++) {
         builder.push(i%10);
     }
-    var result = builder.join();
+    var result = builder.join("");
     var end = new Date().getTime();
     var duration = end - start;
     console.log("join %d^%d %d %d %d", base, power, size, result.length, duration);


### PR DESCRIPTION
With the original blank argument, array.join will insert "," in between elements.
This can be fixed by explicitly providing "" as the argument.
By doing so, this PR will make the behavior of the join experiment consistent with the other experiments.